### PR TITLE
Thibault fillion patch 1

### DIFF
--- a/documentation/building_and_simulating_rds.rst
+++ b/documentation/building_and_simulating_rds.rst
@@ -359,7 +359,7 @@ using simulate_script :
 
   ...
 
-  output = strn.simulate_script(script)
+  output = simulate_script(script, default_engine())
 
 using directly the engine :
 

--- a/documentation/building_and_simulating_rds.rst
+++ b/documentation/building_and_simulating_rds.rst
@@ -316,7 +316,6 @@ using object construction  :
 
   from strengths import *
   import numpy as np
-  import strengths.plot as strnplt
 
   system = load_rdsystem("demo.json")
   script = RDScript(
@@ -330,9 +329,8 @@ from python dict :
 
 .. code:: python
 
-  import strengths as strn
+  from strengths import *
   import numpy as np
-  import strengths.plot as strnplt
 
   script_dict = {
     "system"    : "system.json",
@@ -340,7 +338,7 @@ from python dict :
     "time_step" : "1 ms"
     }
   script = rdscript_from_dict(script_dict)
-  output = strn.simulate_script(script)
+  output = simulate_script(script, default_engine())
 
 from JSON file :
 

--- a/documentation/building_and_simulating_rds.rst
+++ b/documentation/building_and_simulating_rds.rst
@@ -344,12 +344,11 @@ from JSON file :
 
 .. code:: python
 
-  import strengths as strn
+  from strengths import *
   import numpy as np
-  import strengths.plot as strnplt
 
   script = load_rdscript("script.json")
-  output = strn.simulate_script(script)
+  output = simulate_script(script, default_engine())
 
 Simulating the script
 ^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/building_and_simulating_rds.rst
+++ b/documentation/building_and_simulating_rds.rst
@@ -367,13 +367,13 @@ using directly the engine :
 
   ...
   
-  engine = MyEngine()
+  engine = default_engine()
   engine.setup(script)
 
   while engine.iterate() :
     pass
 
-  output = engine.get_output(script)
+  output = engine.get_output()
 
 Another example with diffusion
 ------------------------------

--- a/documentation/building_and_simulating_rds.rst
+++ b/documentation/building_and_simulating_rds.rst
@@ -366,6 +366,7 @@ using directly the engine :
 .. code:: python
 
   ...
+  
   engine = MyEngine()
   engine.setup(script)
 

--- a/documentation/building_and_simulating_rds.rst
+++ b/documentation/building_and_simulating_rds.rst
@@ -314,17 +314,17 @@ using object construction  :
 
 .. code:: python
 
-  import strengths as strn
+  from strengths import *
   import numpy as np
   import strengths.plot as strnplt
 
-  system = strn.load_rdsystem("demo.json")
+  system = load_rdsystem("demo.json")
   script = RDScript(
     system    = system,
-    t_sample  = strn.UnitArray(np.linspace(0,10,1001), "s"),
+    t_sample  = UnitArray(np.linspace(0,10,1001), "s"),
     time_step = "1 ms"
     )
-  output = strn.simulate_script(script)
+  output = simulate_script(script, default_engine())
 
 from python dict :
 

--- a/src/strengths/rdscript.py
+++ b/src/strengths/rdscript.py
@@ -1,5 +1,5 @@
 from strengths.units import *
-from strengths.rdsystem import RDSystem, rdsystem_from_dict, rdsystem_to_dict
+from strengths.rdsystem import RDSystem, rdsystem_from_dict, rdsystem_to_dict, load_rdsystem, save_rdsystem
 from strengths.typechecking import *
 
 import json
@@ -214,7 +214,7 @@ def rdscript_from_dict(d, base_path=None) :
             rds = rdsystem_from_dict(rds, da["units_system"], base_path)
         elif isstr(rds) : 
             rds = filepath.get_path_with_base(rds, base_path)
-            rds = load_drsystem(rds, da["units_system"])
+            rds = load_rdsystem(rds, da["units_system"])
         else :
             raise TypeError("system must be a dictionary.")
         da["system"] = rds


### PR DESCRIPTION
* Fixing errors in the examples in the building_and_simulating_rds.rst, in the section about RDScript.
* Bug fix in rdscript.py : typo which caused an error when loading a RDScript from a dict where "system" is a path/filename.